### PR TITLE
Renaming Plane for Branch Visibility

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -321,7 +321,7 @@ GameObject:
   - component: {fileID: 1759808240}
   - component: {fileID: 1759808239}
   m_Layer: 0
-  m_Name: 'Ground '
+  m_Name: Ground Plane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0


### PR DESCRIPTION
Did this as I created a Task in Kanban called creating a Plane.

It turned out to be in my initial commit.

![image](https://github.com/user-attachments/assets/70b41c2a-4e91-46e3-a2ca-80becfad09ee)
